### PR TITLE
Update json-stringify demo to use single quotes rather than double quotes

### DIFF
--- a/live-examples/js-examples/json/json-stringify.js
+++ b/live-examples/js-examples/json/json-stringify.js
@@ -1,11 +1,11 @@
 console.log(JSON.stringify({ x: 5, y: 6 }));
-// Expected output: "{"x":5,"y":6}"
+// Expected output: '{"x":5,"y":6}'
 
 console.log(JSON.stringify([new Number(3), new String('false'), new Boolean(false)]));
-// Expected output: "[3,"false",false]"
+// Expected output: '[3,"false",false]'
 
 console.log(JSON.stringify({ x: [10, undefined, function(){}, Symbol('')] }));
-// Expected output: "{"x":[10,null,null,null]}"
+// Expected output: '{"x":[10,null,null,null]}'
 
 console.log(JSON.stringify(new Date(2006, 0, 2, 15, 4, 5)));
-// Expected output: ""2006-01-02T15:04:05.000Z""
+// Expected output: '"2006-01-02T15:04:05.000Z"'


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the example output's in the JSON.stringify() demo
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Currently the example is showing double quotes wrapped around the JSON string, when it should be single quotes instead. When you actually run the demo, the results differ from the expected output. This PR was created to address that.
<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
